### PR TITLE
With single transaction Borrower would be able to create the loan request

### DIFF
--- a/contracts/EthLend.sol
+++ b/contracts/EthLend.sol
@@ -321,8 +321,8 @@ contract LendingRequest {
      }
 
      function getCurrentState() constant returns(State){
-        if(currentState == State.WaitingForTokens){
-          if(currentType == Type.TokensCollateral){
+       if(currentState == State.WaitingForTokens){
+         if(currentType == Type.TokensCollateral){
             ERC20Token token = ERC20Token(token_smartcontract_address);
 
             uint tokenBalance = token.balanceOf(this);
@@ -330,20 +330,24 @@ contract LendingRequest {
                // we are ready to search someone 
                // to give us the money
                return State.WaitingForLender;
-            }   
+            }else{
+                return currentState;
+            } 
           }else if(currentType == Type.EnsCollateral){
             AbstractENS ens = AbstractENS(ensRegistryAddress);
             if(ens.owner(ens_domain_hash)==address(this)){
                // we are ready to search someone 
                // to give us the money
                return State.WaitingForLender;
+            }else{
+                return currentState;
             }
           }else{
-            return currentState;
+              return currentState;
           }
-        }else{
-          return currentState;
-        }
+       }else{
+         return currentState;
+       }
 
      }
 

--- a/contracts/EthLend.sol
+++ b/contracts/EthLend.sol
@@ -100,19 +100,48 @@ contract Ledger {
      /// Must be called by Borrower
      // tokens as a collateral 
      function createNewLendingRequest() payable returns(address){
-          return newLr(0);
+          //return newLr(0);
      }
 
      // domain as a collateral 
      function createNewLendingRequestEns() payable returns(address){
-          return newLr(1);
+          //return newLr(1);
      }
      // reputation as a collateral
      function createNewLendingRequestRep() payable returns(address){
-          return newLr(2);
+          //return newLr(2);
      }
+     
+     // new ledger request and set data
+     function newLrAndSetData(int _collateralType, uint _wanted_wei, uint _token_amount, uint _premium_wei,
+                         string _token_name, string _token_infolink, address _token_smartcontract_address, 
+                         uint _days_to_lend, bytes32 _ens_domain_hash) payable returns(address)
+     {
+          if(msg.value < borrowerFeeAmount){
+               revert();
+          }
 
-     function newLr(int _collateralType) payable returns(address out){
+          // 1 - send Fee to wherToSendFee
+          whereToSendFee.transfer(borrowerFeeAmount);
+
+          // 2 - create new LR
+          // will be in state 'WaitingForData'
+          LendingRequest lending_request = new LendingRequest(msg.sender, _collateralType);
+          lending_request.setData(_wanted_wei, _token_amount, _premium_wei, _token_name, _token_infolink, _token_smartcontract_address, _days_to_lend, _ens_domain_hash);
+          
+          // 3 - add to list
+          uint currentCount = lrsCountPerUser[msg.sender];
+          lrsPerUser[msg.sender][currentCount] = lending_request;
+          lrsCountPerUser[msg.sender]++;
+
+          lrs[totalLrCount] = lending_request;
+          totalLrCount++;
+
+          return lending_request;
+
+}
+
+     /*function newLr(int _collateralType) payable returns(address out){
           // 1 - send Fee to wherToSendFee           
           if(msg.value < borrowerFeeAmount){
                revert();
@@ -123,6 +152,7 @@ contract Ledger {
           // 2 - create new LR
           // will be in state 'WaitingForData'
           out = new LendingRequest(msg.sender, _collateralType);
+          
 
           // 3 - add to list
           uint currentCount = lrsCountPerUser[msg.sender];
@@ -131,7 +161,7 @@ contract Ledger {
 
           lrs[totalLrCount] = out;
           totalLrCount++;
-     }
+     }*/
 
 
      function getLrFundedCount() constant returns(uint out){
@@ -201,9 +231,9 @@ contract Ledger {
           return;             
      } 
 
-     function() payable{
+     /*function() payable {
           createNewLendingRequest();
-     }
+     }*/
 }
 
 /*
@@ -273,8 +303,8 @@ contract LendingRequest {
      function getTokenInfoLink() constant returns(string){ return token_infolink; }
      function getEnsDomainHash() constant returns(bytes32){ return ens_domain_hash; }
      function getTokenSmartcontractAddress() constant returns(address){ return token_smartcontract_address; }
-               
-     
+    
+
      modifier onlyByLedger(){
           require(Ledger(msg.sender) == ledger);
           _;
@@ -314,7 +344,7 @@ contract LendingRequest {
           whereToSendFee = ledger.whereToSendFee();
           registrarAddress = ledger.registrarAddress();
           ensRegistryAddress = ledger.ensRegistryAddress();
-                    
+    
           // collateral: tokens or ENS domain?
           if (_collateralType == 0){
                currentType = Type.TokensCollateral;

--- a/test/contract_test.js
+++ b/test/contract_test.js
@@ -712,14 +712,37 @@ describe('Contracts 1', function() {
           done();
      });
 
-     it('should issue new LR',function(done){
+
+     it('should create new LendingRequest and set data',function(done){
           // 0.2 ETH
           var amount = 200000000000000000;
 
-          web3.eth.sendTransaction(
+          var data = {
+               wanted_wei: WANTED_WEI,
+               token_amount: 10,
+               premium_wei: PREMIUM_WEI,
+
+               token_name: 'SampleContract',
+               token_infolink: 'https://some-sample-ico.network',
+
+               // see that?
+               token_smartcontract_address: tokenAddress,
+               days_to_lend: 10
+          };
+
+          // this is set by creator (from within platform)
+          ledgerContract.newLrAndSetData(
+               0,
+               data.wanted_wei,
+               data.token_amount,
+               data.premium_wei,
+               data.token_name,
+               data.token_infolink,
+               data.token_smartcontract_address,
+               data.days_to_lend,
+               0,
                {
                     from: borrower,               
-                    to: ledgerContractAddress,
                     value: amount,
                     gas: 2900000 
                },function(err,result){
@@ -733,6 +756,7 @@ describe('Contracts 1', function() {
                }
           );
      });
+
 
      it('should get updated count of LR',function(done){
           var count = ledgerContract.getLrCount();
@@ -771,8 +795,8 @@ describe('Contracts 1', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Tokens" state
+          assert.equal(state.toString(),1);
           done();
      })
 
@@ -783,52 +807,11 @@ describe('Contracts 1', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Token" state
+          assert.equal(state.toString(),1);
           done();
      })
 
-     it('should set data',function(done){
-          var data = {
-               wanted_wei: WANTED_WEI,
-               token_amount: 10,
-               premium_wei: PREMIUM_WEI,
-
-               token_name: 'SampleContract',
-               token_infolink: 'https://some-sample-ico.network',
-
-               // see that?
-               token_smartcontract_address: tokenAddress,
-               days_to_lend: 10
-          };
-
-          var a = ledgerContract.getLrForUser(borrower,0);
-          var lr = web3.eth.contract(requestAbi).at(a);
-
-          // this is set by creator (from within platform)
-          lr.setData(
-               data.wanted_wei,
-               data.token_amount,
-               data.premium_wei,
-               data.token_name,
-               data.token_infolink,
-               data.token_smartcontract_address,
-               data.days_to_lend,
-               0,
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
-     });
 
      it('should move to Waiting for tokens state',function(done){
           assert.equal(ledgerContract.getLrCountForUser(borrower),1);
@@ -1230,26 +1213,47 @@ describe('Contracts 2 - cancel', function() {
           });
      });
 
-     it('should issue new LR',function(done){
+     it('should issue new LR and set data',function(done){
           // 0.2 ETH
           var amount = 200000000000000000;
-
-          web3.eth.sendTransaction(
+          
+          var data = {
+               wanted_wei: WANTED_WEI,
+               token_amount: 10,
+               premium_wei: PREMIUM_WEI,
+          
+               token_name: 'SampleContract',
+               token_infolink: 'https://some-sample-ico.network',
+          
+               // see that?
+               token_smartcontract_address: tokenAddress,
+               days_to_lend: 10
+          };
+          
+          // this is set by creator (from within platform)
+          ledgerContract.newLrAndSetData(
+               0,
+               data.wanted_wei,
+               data.token_amount,
+               data.premium_wei,
+               data.token_name,
+               data.token_infolink,
+               data.token_smartcontract_address,
+               data.days_to_lend,
+               0,
                {
                     from: borrower,               
-                    to: ledgerContractAddress,
                     value: amount,
                     gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+                    },function(err,result){
+                         assert.equal(err,null);
+          
+                         web3.eth.getTransactionReceipt(result, function(err, r2){
+                              assert.equal(err, null);
+                                   done();
+                              });
+                         }
+                    );
      });
 
      it('should get updated count of LR',function(done){
@@ -1263,8 +1267,8 @@ describe('Contracts 2 - cancel', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Tokens" state
+          assert.equal(state.toString(),1);
           done();
      })
 
@@ -1476,23 +1480,45 @@ describe('Contracts 3 - cancel with refund', function() {
           done();
      });
 
-     it('should issue new LR',function(done){
+     it('should issue new LR and set data',function(done){
           // 0.2 ETH
           var amount = 200000000000000000;
-
-          web3.eth.sendTransaction(
+          
+          var data = {
+               wanted_wei: WANTED_WEI,
+               token_amount: 10,
+               premium_wei: PREMIUM_WEI,
+          
+               token_name: 'SampleContract',
+               token_infolink: 'https://some-sample-ico.network',
+          
+               // see that?
+               token_smartcontract_address: tokenAddress,
+               days_to_lend: 10
+          };
+          
+          // this is set by creator (from within platform)
+          ledgerContract.newLrAndSetData(
+               0,
+               data.wanted_wei,
+               data.token_amount,
+               data.premium_wei,
+               data.token_name,
+               data.token_infolink,
+               data.token_smartcontract_address,
+               data.days_to_lend,
+               0,
                {
                     from: borrower,               
-                    to: ledgerContractAddress,
                     value: amount,
                     gas: 2900000 
                },function(err,result){
                     assert.equal(err,null);
-
+          
                     web3.eth.getTransactionReceipt(result, function(err, r2){
                          assert.equal(err, null);
-
-                         done();
+          
+                              done();
                     });
                }
           );
@@ -1535,8 +1561,8 @@ describe('Contracts 3 - cancel with refund', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Tokens" state
+          assert.equal(state.toString(),1);
           done();
      })
 
@@ -1547,52 +1573,10 @@ describe('Contracts 3 - cancel with refund', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Tokens" state
+          assert.equal(state.toString(),1);
           done();
      })
-
-     it('should set data',function(done){
-          var data = {
-               wanted_wei: WANTED_WEI,
-               token_amount: 10,
-               premium_wei: PREMIUM_WEI,
-
-               token_name: 'SampleContract',
-               token_infolink: 'https://some-sample-ico.network',
-
-               // see that?
-               token_smartcontract_address: tokenAddress,
-               days_to_lend: 10
-          };
-
-          var a = ledgerContract.getLrForUser(borrower,0);
-          var lr = web3.eth.contract(requestAbi).at(a);
-
-          // this is set by creator (from within platform)
-          lr.setData(
-               data.wanted_wei,
-               data.token_amount,
-               data.premium_wei,
-               data.token_name,
-               data.token_infolink,
-               data.token_smartcontract_address,
-               data.days_to_lend,
-               0,
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
-     });
 
      it('should move to Waiting for tokens state',function(done){
           assert.equal(ledgerContract.getLrCountForUser(borrower),1);
@@ -1604,7 +1588,7 @@ describe('Contracts 3 - cancel with refund', function() {
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
-     })
+     });
 
      it('should check if tokens are transferred',function(done){
           var a = ledgerContract.getLrForUser(borrower,0);
@@ -1886,26 +1870,48 @@ describe('Contracts 4 - default', function() {
           done();
      });
 
-     it('should issue new LR',function(done){
-          // 0.2 ETH
-          var amount = 200000000000000000;
-
-          web3.eth.sendTransaction(
-               {
-                    from: borrower,               
-                    to: ledgerContractAddress,
-                    value: amount,
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+     it('should issue new LR and set data',function(done){
+      // 0.2 ETH
+      var amount = 200000000000000000;
+      
+     var data = {
+          wanted_wei: WANTED_WEI,
+          token_amount: 10,
+          premium_wei: PREMIUM_WEI,
+      
+          token_name: 'SampleContract',
+          token_infolink: 'https://some-sample-ico.network',
+      
+                     // see that?
+          token_smartcontract_address: tokenAddress,
+          days_to_lend: 10
+     };
+          
+     // this is set by creator (from within platform)
+     ledgerContract.newLrAndSetData(
+          0,
+          data.wanted_wei,
+          data.token_amount,
+          data.premium_wei,
+          data.token_name,
+          data.token_infolink,
+          data.token_smartcontract_address,
+          data.days_to_lend,
+          0,
+          {
+               from: borrower,               
+               value: amount,
+               gas: 2900000 
+          },function(err,result){
+               assert.equal(err,null);
+      
+               web3.eth.getTransactionReceipt(result, function(err, r2){
+                    assert.equal(err, null);
+      
+                    done();
+               });
+          }
+     );
      });
 
      it('should get updated count of LR',function(done){
@@ -1945,8 +1951,8 @@ describe('Contracts 4 - default', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Tokens" state
+          assert.equal(state.toString(),1);
           done();
      })
 
@@ -1957,52 +1963,12 @@ describe('Contracts 4 - default', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for Tokens" state
+          assert.equal(state.toString(),1);
           done();
      })
 
-     it('should set data',function(done){
-          var data = {
-               wanted_wei: WANTED_WEI,
-               token_amount: 10,
-               premium_wei: PREMIUM_WEI,
-
-               token_name: 'SampleContract',
-               token_infolink: 'https://some-sample-ico.network',
-
-               // see that?
-               token_smartcontract_address: tokenAddress,
-               days_to_lend: 10
-          };
-
-          var a = ledgerContract.getLrForUser(borrower,0);
-          var lr = web3.eth.contract(requestAbi).at(a);
-
-          // this is set by creator (from within platform)
-          lr.setData(
-               data.wanted_wei,
-               data.token_amount,
-               data.premium_wei,
-               data.token_name,
-               data.token_infolink,
-               data.token_smartcontract_address,
-               data.days_to_lend,
-               0,
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
-     });
+     
 
      it('should move to Waiting for tokens state',function(done){
           assert.equal(ledgerContract.getLrCountForUser(borrower),1);
@@ -2334,14 +2300,50 @@ describe('Contracts 5 - domain', function() {
      });
 
      it('should issue new ENS LR',function(done){
-          var params = {from: borrower,to: ledgerContractAddress, value: 200000000000000000, gas: 2900000} 
-          ledgerContract.createNewLendingRequestEns(params, (err,res)=>{
-               assert.equal(err, null);
-               web3.eth.getTransactionReceipt(res, (err, res2)=>{
-                    assert.equal(err, null);
-                    done();
-               });                   
-          });
+      var amount = 200000000000000000;
+      
+      var data = {
+            wanted_wei: WANTED_WEI,
+            token_amount: 0,
+            premium_wei: PREMIUM_WEI,
+
+            token_name: '',
+            token_infolink: 'https://some-sample-ico.network',
+
+            // see that?
+            token_smartcontract_address: 0,
+            days_to_lend: 10,
+            ens_domain_hash: domainHash
+       };
+      
+          //var a = ledgerContract.getLrForUser(borrower,0);
+          //var lr = web3.eth.contract(requestAbi).at(a);
+
+          // this is set by creator (from within platform)
+      ledgerContract.newLrAndSetData(
+         1,
+         data.wanted_wei,
+         data.token_amount,
+         data.premium_wei,
+         data.token_name,
+         data.token_infolink,
+         data.token_smartcontract_address,
+         data.days_to_lend,
+         data.ens_domain_hash,
+         {
+              from: borrower,               
+              value: amount,
+              gas: 2900000 
+         },function(err,result){
+              assert.equal(err,null);
+
+              web3.eth.getTransactionReceipt(result, function(err, r2){
+                   assert.equal(err, null);
+
+                   done();
+              });
+         }
+      );
      });
 
      it('should get updated count of LR',function(done){
@@ -2381,8 +2383,8 @@ describe('Contracts 5 - domain', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for domain" state
+          assert.equal(state.toString(),1);
           done();
      })
 
@@ -2393,54 +2395,10 @@ describe('Contracts 5 - domain', function() {
           var lr = web3.eth.contract(requestAbi).at(a);
 
           var state = lr.getState();
-          // "Waiting for data" state
-          assert.equal(state.toString(),0);
+          // "Waiting for domain" state
+          assert.equal(state.toString(),1);
           done();
      })
-
-     it('should set data',function(done){
-          var data = {
-               wanted_wei: WANTED_WEI,
-               token_amount: 0,
-               premium_wei: PREMIUM_WEI,
-
-               token_name: '',
-               token_infolink: 'https://some-sample-ico.network',
-
-               // see that?
-               token_smartcontract_address: 0,
-               days_to_lend: 10,
-               ens_domain_hash: domainHash
-          };
-
-          var a = ledgerContract.getLrForUser(borrower,0);
-          var lr = web3.eth.contract(requestAbi).at(a);
-
-
-          // this is set by creator (from within platform)
-          lr.setData(
-               data.wanted_wei,
-               data.token_amount,
-               data.premium_wei,
-               data.token_name,
-               data.token_infolink,
-               data.token_smartcontract_address,
-               data.days_to_lend,
-               data.ens_domain_hash,
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
-     });
 
      it('should move to Waiting for domain state',function(done){
           assert.equal(ledgerContract.getLrCountForUser(borrower),1);
@@ -2598,4 +2556,3 @@ describe('Contracts 5 - domain', function() {
           done();
      })
 });
-

--- a/test/contract_test.js
+++ b/test/contract_test.js
@@ -794,7 +794,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -806,7 +806,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Token" state
           assert.equal(state.toString(),1);
           done();
@@ -819,7 +819,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -829,20 +829,10 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),1);
+          done();
      });
 
      it('should not move into <WaitingForLender> state',function(done){
@@ -851,7 +841,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -883,20 +873,10 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),1);
+          done();
      });
 
      it('should not move into <WaitingForLender> state',function(done){
@@ -905,7 +885,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -943,20 +923,10 @@ describe('Contracts 1', function() {
           var balance2 = token.balanceOf(a);
           assert.equal(balance2,10);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),3);
+          done();
      });
 
      it('should move into <WaitingForLender> state',function(done){
@@ -965,7 +935,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for lender" state
           assert.equal(state.toString(),3);
           done();
@@ -975,15 +945,10 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    // TODO: why fails?
-                    done();
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),3);
+          done();
      });
 
      it('should collect money from Lender now',function(done){
@@ -1040,7 +1005,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting For Payback" state
           assert.equal(state.toString(),4);
           done();
@@ -1089,7 +1054,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // still in "Waiting For Payback" state
           assert.equal(state.toString(),4);
           done();
@@ -1126,7 +1091,7 @@ describe('Contracts 1', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Finished" state
           assert.equal(state.toString(),6);
           done();
@@ -1266,7 +1231,7 @@ describe('Contracts 2 - cancel', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1298,7 +1263,7 @@ describe('Contracts 2 - cancel', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Cancelled" state
           assert.equal(state.toString(),2);
           done();
@@ -1324,7 +1289,7 @@ describe('Contracts 2 - cancel', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Cancelled" state
           assert.equal(state.toString(),2);
           done();
@@ -1560,7 +1525,7 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1572,7 +1537,7 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1584,7 +1549,7 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1594,20 +1559,10 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),1);
+          done();
      });
 
      it('should not move into <WaitingForLender> state',function(done){
@@ -1616,7 +1571,7 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1659,20 +1614,10 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),3);
+          done();
      });
 
      it('should move into <WaitingForLender> state',function(done){
@@ -1681,7 +1626,7 @@ describe('Contracts 3 - cancel with refund', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for lender" state
           assert.equal(state.toString(),3);
           done();
@@ -1950,7 +1895,7 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1962,7 +1907,7 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for Tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1976,7 +1921,7 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -1986,20 +1931,10 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),1);
+          done();
      });
 
      it('should not move into <WaitingForLender> state',function(done){
@@ -2008,7 +1943,7 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -2051,20 +1986,10 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkTokens(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),3);
+          done();
      });
 
      it('should move into <WaitingForLender> state',function(done){
@@ -2073,7 +1998,7 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for lender" state
           assert.equal(state.toString(),3);
           done();
@@ -2116,7 +2041,7 @@ describe('Contracts 4 - default', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting For Payback" state
           assert.equal(state.toString(),4);
           done();
@@ -2382,7 +2307,7 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLr(0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for domain" state
           assert.equal(state.toString(),1);
           done();
@@ -2394,7 +2319,7 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for domain" state
           assert.equal(state.toString(),1);
           done();
@@ -2406,7 +2331,7 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for domain" state
           assert.equal(state.toString(),1);
           done();
@@ -2416,20 +2341,10 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkDomain(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),1);
+          done();
      });
 
      it('should not move into <WaitingForLender> state',function(done){
@@ -2438,7 +2353,7 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),1);
           done();
@@ -2463,20 +2378,10 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          lr.checkDomain(
-               {
-                    from: borrower,               
-                    gas: 2900000 
-               },function(err,result){
-                    assert.equal(err,null);
-
-                    web3.eth.getTransactionReceipt(result, function(err, r2){
-                         assert.equal(err, null);
-
-                         done();
-                    });
-               }
-          );
+          var state = lr.getCurrentState();
+          // "Waiting for tokens" state
+          assert.equal(state.toString(),3);
+          done();
      });
 
 
@@ -2486,7 +2391,7 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting for tokens" state
           assert.equal(state.toString(),3);
           done();
@@ -2550,7 +2455,7 @@ describe('Contracts 5 - domain', function() {
           var a = ledgerContract.getLrForUser(borrower,0);
           var lr = web3.eth.contract(requestAbi).at(a);
 
-          var state = lr.getState();
+          var state = lr.getCurrentState();
           // "Waiting For Payback" state
           assert.equal(state.toString(),4);
           done();


### PR DESCRIPTION
- Earlier to create new loan request by the Borrower, he has to sign two transactions.
- Now with the change, he can do this with single transaction only.
- getCurrentState() method is added to check that the ERC20 tokens has been received. Now after this change, Borrower do not have to pay the fee every time to check that his ERC20 tokens are received or not.